### PR TITLE
HTML content opener

### DIFF
--- a/jquery-sortable-lists.js
+++ b/jquery-sortable-lists.js
@@ -43,6 +43,7 @@
 				},
 				opener: {
 					active: false,
+					as: 'img',
 					open: '',
 					close: '',
 					openerCss: {
@@ -96,7 +97,6 @@
 			// Is +/- ikon to open/close nested lists
 			opener = $( '<span />' )
 				.addClass( 'sortableListsOpener ' + setting.opener.openerClass )
-				.css( 'background-image', 'url(' + setting.opener.close + ')' )
 				.css( setting.opener.openerCss )
 				.on( 'mousedown', function( e )
 				{
@@ -106,10 +106,12 @@
 					else { close( li ); }
 
 					return false; // Prevent default
-				}),
+				});
+
+		set_open_close( opener, 'close' );
 
 			// Container with all actual elements and parameters
-			state = {
+			var state = {
 				isDragged: false,
 				isRelEFP: null,  // How browser counts elementFromPoint() position (relative to window/document)
 				oEl: null, // overElement is element which returns elementFromPoint() method
@@ -129,8 +131,10 @@
 
 		if ( setting.opener.active )
 		{
-			if ( ! setting.opener.open ) throw 'Url for opener.open image is not defined';
-			if ( ! setting.opener.close ) throw 'Url for opener.close image is not defined';
+			if ( ! setting.opener.as || (setting.opener.as !== 'img' && setting.opener.as !== 'html') )
+				throw 'Value for opener.as must be "img" or "html"';
+			if ( ! setting.opener.open ) throw 'Value opener.open is not defined';
+			if ( ! setting.opener.close ) throw 'Value opener.close is not defined';
 
 			$( this ).find( 'li' ).each( function() {
 				var li = $( this );
@@ -676,7 +680,7 @@
 		{
 			li.removeClass( 'sortableListsClosed' ).addClass( 'sortableListsOpen' );
 			li.children( 'ul, ol' ).css( 'display', 'block' );
-			li.children( 'div' ).children( '.sortableListsOpener' ).first().css( 'background-image', 'url(' + setting.opener.close + ')' );
+			set_open_close( li.children( 'div' ).children( '.sortableListsOpener' ).first(), 'close' );
 		}
 
 		/**
@@ -687,7 +691,26 @@
 		{
 			li.removeClass( 'sortableListsOpen' ).addClass( 'sortableListsClosed' );
 			li.children( 'ul, ol' ).css( 'display', 'none' );
-			li.children( 'div' ).children( '.sortableListsOpener' ).first().css( 'background-image', 'url(' + setting.opener.open + ')' );
+			set_open_close( li.children( 'div' ).children( '.sortableListsOpener' ).first(), 'open' );
+		}
+
+		/**
+		 * @desc Handles display of open/close image or html
+		 * @param el
+		 * @param state
+		 */
+		function set_open_close( el, state )
+		{
+			var value = setting.opener[state];
+
+			if( setting.opener.as === 'img' )
+			{
+				el.css( 'background-image', 'url(' + value + ')' );
+			}
+			else if( setting.opener.as === 'html' )
+			{
+				el.html( value );
+			}
 		}
 
 		/**

--- a/jquery-sortable-lists.js
+++ b/jquery-sortable-lists.js
@@ -108,7 +108,7 @@
 					return false; // Prevent default
 				});
 
-		set_open_close( opener, 'close' );
+		setOpenClose( opener, 'close' );
 
 			// Container with all actual elements and parameters
 			var state = {
@@ -131,8 +131,7 @@
 
 		if ( setting.opener.active )
 		{
-			if ( ! setting.opener.as || (setting.opener.as !== 'img' && setting.opener.as !== 'html') )
-				throw 'Value for opener.as must be "img" or "html"';
+			if ( setting.opener.as !== 'img' && setting.opener.as !== 'html') throw 'Value for opener.as must be "img" or "html"';
 			if ( ! setting.opener.open ) throw 'Value opener.open is not defined';
 			if ( ! setting.opener.close ) throw 'Value opener.close is not defined';
 
@@ -680,7 +679,7 @@
 		{
 			li.removeClass( 'sortableListsClosed' ).addClass( 'sortableListsOpen' );
 			li.children( 'ul, ol' ).css( 'display', 'block' );
-			set_open_close( li.children( 'div' ).children( '.sortableListsOpener' ).first(), 'close' );
+			setOpenClose( li.children( 'div' ).children( '.sortableListsOpener' ).first(), 'close' );
 		}
 
 		/**
@@ -691,7 +690,7 @@
 		{
 			li.removeClass( 'sortableListsOpen' ).addClass( 'sortableListsClosed' );
 			li.children( 'ul, ol' ).css( 'display', 'none' );
-			set_open_close( li.children( 'div' ).children( '.sortableListsOpener' ).first(), 'open' );
+			setOpenClose( li.children( 'div' ).children( '.sortableListsOpener' ).first(), 'open' );
 		}
 
 		/**
@@ -699,7 +698,7 @@
 		 * @param el
 		 * @param state
 		 */
-		function set_open_close( el, state )
+		function setOpenClose( el, state )
 		{
 			var value = setting.opener[state];
 


### PR DESCRIPTION
Add functionality to use HTML code for the open and close openers content by setting `opener.as = 'html'`, allowing for example to use font-awesome icons by writing options like this :

```
    options =
      ...
      opener:
        active: true
        as: 'html'
        close: '<i class="fa fa-plus"></i>'
        open: '<i class="fa fa-minus"></i>'
        openerCss:
          'float': 'left'
          'margin-left': '-27px'
          'margin-top': '1px'
          'cursor': 'pointer'

    $('ul#hierarchy-tree').sortableLists options
```

![opener](https://cloud.githubusercontent.com/assets/3615944/10116045/3e4a4d70-6423-11e5-8dcf-ddc7fd2fa2ae.png)

