### PR TITLE
Add mobile js files to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,8 @@
   "files": [
     "jquery-sortable-lists.js",
     "jquery-sortable-lists.min.js",
+    "jquery-sortable-lists-mobile.js",
+    "jquery-sortable-lists-mobile.min.js",
     "LICENCE",
     "README.md",
     "imgs"


### PR DESCRIPTION
Add missing jquery-sortable-lists-mobile files to be included in the package.json files.